### PR TITLE
Add support for idlpp's `-j` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [UNRELEASED](https://github.com/atolab/vortex-gateway/tree/master)
+ - add `renamePackages` to `opensplice-idl-plugin` (uses idlpp's `-j` option)
 
 ## [3.0.1](https://github.com/atolab/vortex-gateway/tree/V3.0.0) - 2018-05-14
 

--- a/opensplice-idl-plugin/README.adoc
+++ b/opensplice-idl-plugin/README.adoc
@@ -33,37 +33,41 @@ source files to be compiled by Maven during the "compile" phase.
 
 In addition, the following optional parameters can be configured:
 
-[options="header",cols="15,15,70"]
+[options="header",cols="18,15,70"]
 |===============================================================================
-|  Name       | Type     | Description
+|  Name          | Type     | Description
 
-| outDir      | File     | The directory to output the generated sources to.
+| outDir         | File     | The directory to output the generated sources to.
 
-                           Default value is:
-                           *${project.build.directory}/generated-sources/idl*
+                              Default value is:
+                              *${project.build.directory}/generated-sources/idl*
 
-| includeDirs | File[]   | Additional include directories containing additional
-                           *.idl files required for compilation.
+| includeDirs    | File[]   | Additional include directories containing
+                              additional *.idl files required for compilation.
 
-| idlDir      | File     | The source directory containing +++*+++.idl files.
+| idlDir         | File     | The source directory containing +++*+++.idl files.
 
-                           Default value is:
-                           *${basedir}/src/main/idl*
+                              Default value is:
+                              *${basedir}/src/main/idl*
 
-| macros      | String[] | Preprocessing macros definitions
-                           (used with `-D` options)
+| macros         | String[] | Preprocessing macros definitions
+                              (used with `-D` options)
 
-| idlc        | String   | The compiler executable.
+| idlc           | String   | The compiler executable.
 
-                           Default value is: *idlc*
+                              Default value is: *idlc*
 
-| language    | String   | The language of generated code.
-                           Should be one of `java`, `c`, `c++` or `cs`.
+| language       | String   | The language of generated code.
+                              Should be one of `java`, `c`, `c++` or `cs`.
 
-                           Default value is: *java*
+                              Default value is: *java*
 
-| mode        | String   | Standalone or CORBA mode.
-                           Should be either `-S` or `-C`.
+| mode           | String   | Standalone or CORBA mode.
+                              Should be either `-S` or `-C`.
 
-                           Default value is: *-S*
+                              Default value is: *-S*
+
+| renamePackages | String[] | Rename or prefix packages using the idlpp's `-j`
+                              option. Applies only when generating Java code.
+
 |===============================================================================

--- a/opensplice-idl-plugin/src/main/java/com/adlinktech/gateway/idlcompiler/IDLMojo.java
+++ b/opensplice-idl-plugin/src/main/java/com/adlinktech/gateway/idlcompiler/IDLMojo.java
@@ -104,6 +104,15 @@ public class IDLMojo
    private String mode;
 
    /**
+    * rename packages. renames should be specified in the form "[old]:new". if "old" is specified,
+    * then the (partial) package name matching "old" is replaced with "new". otherwise, all packages
+    * prefixed with "new". applicable only for the Java programming language
+    * @ parameter
+    */
+   @Parameter
+   private String[] renamePackages;
+
+   /**
     * Process arguments
     */
    private List<String> arguments;
@@ -165,6 +174,15 @@ public class IDLMojo
          {
             arguments.add("-I");
             arguments.add(includeDirs[x].getAbsolutePath());
+         }
+      }
+
+      if (renamePackages != null && renamePackages.length > 0)
+      {
+         for (int x = 0; x < renamePackages.length; x++)
+         {
+            arguments.add("-j");
+            arguments.add(renamePackages[x]);
          }
       }
 

--- a/opensplice-idl-plugin/src/test/java/com/adlinktech/gateway/idlcompiler/IDLMojoTest.java
+++ b/opensplice-idl-plugin/src/test/java/com/adlinktech/gateway/idlcompiler/IDLMojoTest.java
@@ -86,6 +86,11 @@ public class IDLMojoTest
       String mode = (String) getVariableValueFromObject(mojo, "mode");
       assertTrue(mode.equals("-S"));
 
+      String[] renames = (String[]) getVariableValueFromObject(mojo, "renamePackages");
+      assertTrue(renames.length == 2);
+      assertTrue(renames[0].equals("package:my.package"));
+      assertTrue(renames[1].equals("from.package:to.package"));
+
       File idlDir = (File) getVariableValueFromObject(mojo, "idlDir");
       assertTrue(idlDir.getName().equals("project1"));
 

--- a/opensplice-idl-plugin/src/test/resources/project1/pom.xml
+++ b/opensplice-idl-plugin/src/test/resources/project1/pom.xml
@@ -73,6 +73,10 @@
                         <macro>Hello</macro>
                         <macro>World</macro>
                     </macros>
+                    <renamePackages>
+                      <renamePackage>package:my.package</renamePackage>
+                      <renamePackage>from.package:to.package</renamePackage>
+                    </renamePackages>
                     <language>java</language>
                     <mode>-S</mode>
                 </configuration>


### PR DESCRIPTION
We make use of idlpp's `-j` option to partially rename the package in a Java project.
